### PR TITLE
link BASE logo to BASE, fix typo in covenant URL

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -21,5 +21,5 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 opening an issue or contacting one or more of the project maintainers.
 
 This Code of Conduct is adapted from the Contributor Covenant 
-(http:contributor-covenant.org), version 1.0.0, available at 
+(http://contributor-covenant.org), version 1.0.0, available at 
 http://contributor-covenant.org/version/1/0/0/

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,9 +15,9 @@ knitr::opts_chunk$set(
 * [BASE API docs][docs]
 * [BASE - request access][token]
 
-Data from Bielefeld Academic Search Engine <https://www.base-search.net>
+Data from BASE (Bielefeld Academic Search Engine) <https://www.base-search.net>
 
-<img src="inst/img/BASE_search_engine_logo.svg.png" width="300">
+[<img src="inst/img/BASE_search_engine_logo.svg.png" width="300">](https://www.base-search.net)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ rbace
 * [BASE API docs][docs]
 * [BASE - request access][token]
 
-Data from Bielefeld Academic Search Engine <https://www.base-search.net>
+Data from BASE (Bielefeld Academic Search Engine) <https://www.base-search.net>
 
-<img src="inst/img/BASE_search_engine_logo.svg.png" width="300">
+[<img src="inst/img/BASE_search_engine_logo.svg.png" width="300">](https://www.base-search.net)
 
 ## Install
 
@@ -68,7 +68,7 @@ bs_meta(res)
 #>            <chr>
 #> 1 creator:manghi
 #> # ... with 3 more variables: fl <chr>, fq <chr>, start <dbl>
-#>
+#> 
 #> $response
 #> # A tibble: 1 × 2
 #>   status num_found


### PR DESCRIPTION
Two tiny fixes:

- I like it when the BASE logo links to BASE
- Slashes were missing in the covenant URL

Sorry for the extra space character in README.md -- it was knitr who did it!